### PR TITLE
Issue #29 - https://github.com/alsoscotland/react-super-select/issues/29

### DIFF
--- a/src/__tests__/react-super-select-spec.js
+++ b/src/__tests__/react-super-select-spec.js
@@ -1233,4 +1233,83 @@ describe('ReactSuperSelect', function() {
       expect(customHeadings.length).toBe(3);
     });
   });
+
+  describe('componentWillReceiveProps', function() {
+
+    var parent,
+        testParentComponent,
+        optOne = {
+          id: 1,
+          name: "Test Option 1",
+          foo: "Foo1",
+          bar: "Bar1"
+        },
+        optTwo = {
+          id: 2,
+          name: "Test Option 2",
+          foo: "Foo2",
+          bar: "Bar2"
+        };
+
+    beforeEach(function() {
+      testParentComponent = React.createFactory(React.createClass({
+        getInitialState: function() {
+          return {
+            dataSource: [optOne, optTwo],
+            initialValue: optOne,
+            optionLabelKey: undefined,
+            optionValueKey: undefined
+          };
+        },
+        render: function() {
+          return React.createElement(ReactSuperSelect, {
+                    ref: "rss",
+                    onChange: _.noop,
+                    dataSource: this.state.dataSource,
+                    initialValue: this.state.initialValue,
+                    optionLabelKey: this.state.optionLabelKey,
+                    optionValueKey: this.state.optionValueKey
+                  });
+        }
+      }));
+      parent = TestUtils.renderIntoDocument(testParentComponent());
+    });
+
+    it('resets to new initial value on initial value prop change', function() {
+      expect(parent.refs.rss.props.initialValue).toBe(optOne);
+      expect(_.isEqual(parent.refs.rss.state.value, [optOne])).toBe(true);
+      parent.setState({
+        initialValue: optTwo
+      });
+      expect(parent.refs.rss.props.initialValue).toBe(optTwo);
+      expect(_.isEqual(parent.refs.rss.state.value, [optTwo])).toBe(true);
+    });
+
+    it('will update the optionLabel Key', function() {
+      expect(parent.refs.rss.state.labelKey).toBe("name");
+      parent.setState({
+        optionLabelKey: "foo"
+      });
+      expect(parent.refs.rss.state.labelKey).toBe("foo");
+    });
+
+    it('will update the optionValue Key', function() {
+      expect(parent.refs.rss.state.valueKey).toBe("id");
+      parent.setState({
+        optionValueKey: "bar"
+      });
+      expect(parent.refs.rss.state.valueKey).toBe("bar");
+    });
+
+    it('will update on dataSource change', function() {
+      var lastData = parent.refs.rss.state.data;
+      parent.setState({
+        dataSource: [optTwo]
+      });
+      expect(_.isEqual(parent.refs.rss.state.data, lastData)).toBeFalsy();
+      expect(_.isEqual(parent.refs.rss.state.rawDataSource, [optTwo])).toBeTruthy();
+      expect(parent.refs.rss.state.lastOptionId).toBe(0);
+    });
+
+  });
 });

--- a/src/react-super-select.js
+++ b/src/react-super-select.js
@@ -226,20 +226,38 @@ var ReactSuperSelect = React.createClass({
   // **lastUserSelectedOptionData** - A store of the last user-selected option, used for accesibility-related option focusing, as well as shift-click selection
   lastUserSelectedOption: undefined,
 
-  // If parent page updates the data source, reset the control with some defaults and the new dataSource.
+  // If parent page updates the data source, reset all control state values which are derived from props.
+  // Reset some state defaults and dataSource related fields if dataSource changed.
   componentWillReceiveProps: function(nextProps) {
+    var newState = {};
+
+    if (!_.isEqual(nextProps.initialValue, this.props.initialValue)) {
+      newState.value = this._buildInitialValue(nextProps)
+    }
+
+    if (!_.isUndefined(nextProps.optionLabelKey) && (nextProps.optionLabelKey !== this.props.optionLabelKey)) {
+      newState.labelKey = nextProps.optionLabelKey;
+    }
+
+    if (!_.isUndefined(nextProps.optionValueKey) && (nextProps.optionValueKey !== this.props.optionValueKey)) {
+      newState.valueKey = nextProps.optionValueKey;
+    }
+
     if (!_.isEqual(this.props.dataSource, nextProps.dataSource)) {
 
       this.lastUserSelectedOption = undefined;
 
-      this.setState({
+      newState = _.extend(newState, {
         data: this._configureDataSource(nextProps.dataSource),
         rawDataSource: nextProps.dataSource,
         focusedId: undefined,
-        labelKey: nextProps.optionLabelKey || 'name',
         lastOptionId: (_.isArray(nextProps.dataSource) && (nextProps.dataSource.length > 0)) ? nextProps.dataSource.length - 1 : undefined,
-        valueKey: nextProps.optionValueKey || 'id'
       });
+
+    }
+
+    if (!_.isEmpty(newState)) {
+      this.setState(newState);
     }
   },
 
@@ -319,12 +337,13 @@ var ReactSuperSelect = React.createClass({
     return this.state.controlId + '_list';
   },
 
-  // calculate the initial value for the control from props
-  _buildInitialValue: function() {
+  // calculate the initial value for the control from props, componentWillReceiveProps will call passing nextProps
+  _buildInitialValue: function(props) {
+    props = props || this.props;
     var initialValue = [];
 
-    if (!_.isUndefined(this.props.initialValue)) {
-      initialValue = _.isArray(this.props.initialValue) ? this.props.initialValue : [this.props.initialValue];
+    if (!_.isUndefined(props.initialValue)) {
+      initialValue = _.isArray(props.initialValue) ? props.initialValue : [props.initialValue];
 
       if (!this._isMultiSelect()) {
         initialValue = [_.first(initialValue)];


### PR DESCRIPTION
Adjusting the componentWillReceiveProps method to account for resetting all state variables that are derived from props