### PR TITLE
Fix #89 props didn't set when Object.setPrototypeOf called in IE 9

### DIFF
--- a/lib/react-super-select.js
+++ b/lib/react-super-select.js
@@ -53,6 +53,8 @@ var ReactSuperSelect = function (_React$Component) {
 
     var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(ReactSuperSelect).call(this, props));
 
+    this.props = props;
+
     _this.SEARCH_FOCUS_ID = -1;
 
     // regular expression used to determine if event src options have selected class


### PR DESCRIPTION
Fix #89  props didn't set when Object.setPrototypeOf called in IE 9