### PR TITLE
fix bug #107

### DIFF
--- a/lib/react-super-select.js
+++ b/lib/react-super-select.js
@@ -846,11 +846,15 @@ var ReactSuperSelect = function (_React$Component) {
         optionsCount = 0;
 
     if (!(0, _lodash.isArray)(data)) {
-      (0, _lodash.forIn)(data, function (groupedOptions, heading) {
-        options.push(_this12._getGroupHeadingMarkup(heading));
-        options = options.concat(_this12._getTemplatedOptions(groupedOptions, optionsCount));
-        optionsCount = optionsCount + groupedOptions.length;
-      });
+      if (!(0, _lodash.isEmpty)(data)) {
+        (0, _lodash.forIn)(data, function (groupedOptions, heading) {
+          options.push(_this12._getGroupHeadingMarkup(heading));
+          options = options.concat(_this12._getTemplatedOptions(groupedOptions, optionsCount));
+          optionsCount = optionsCount + groupedOptions.length;
+        });
+      } else {
+        options = this._getTemplatedOptions([]);
+      }
     } else {
       options = this._getTemplatedOptions(data);
     }

--- a/src/react-super-select.js
+++ b/src/react-super-select.js
@@ -761,11 +761,16 @@ class ReactSuperSelect extends React.Component {
         optionsCount = 0;
 
     if (!isArray(data)) {
-      forIn(data, (groupedOptions, heading) => {
-        options.push(this._getGroupHeadingMarkup(heading));
-        options = options.concat(this._getTemplatedOptions(groupedOptions, optionsCount));
-        optionsCount = optionsCount + groupedOptions.length;
-      });
+      if(!isEmpty(data)){
+        forIn(data, (groupedOptions, heading) => {
+          options.push(this._getGroupHeadingMarkup(heading));
+          options = options.concat(this._getTemplatedOptions(groupedOptions, optionsCount));
+          optionsCount = optionsCount + groupedOptions.length;
+        });
+      }
+      else{
+        options = this._getTemplatedOptions([]);
+      }
     } else {
       options = this._getTemplatedOptions(data);
     }


### PR DESCRIPTION
When groupBy option is set, 'No result found' does not work, because for that to happen data is expected to be an empty array, where is it is an Object (because groupBy is enabled)