### PR TITLE
Add babel-plugin-lodash

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
               ["es2015", {"loose": true}]
              ],
   "plugins": [
+    "lodash",
     "transform-react-constant-elements"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",
+    "babel-plugin-lodash": "^3.3.2",
     "babel-plugin-object-assign": "^1.2.1",
     "babel-plugin-transform-react-constant-elements": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",


### PR DESCRIPTION
As the module currently exists, when you bundle it into a project using webpack, the entirety of lodash is pulled in, ~600kb.

By adding babel-plugin-lodash, the actual lodash modules you use are cherry-picked and used directly, reducing eventual lodash includes to about ~150kb.

There should be no functional difference, this change should be seamless.