### PR TITLE
Add babel-preset-minify to minify build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": [ "react",
-              ["es2015", {"loose": true}]
+              ["es2015", {"loose": true}],
+              "minify"
              ],
   "plugins": [
     "lodash",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-plugin-object-assign": "^1.2.1",
     "babel-plugin-transform-react-constant-elements": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
+    "babel-preset-minify": "^0.3.0",
     "babel-preset-react": "^6.24.1",
     "babelify": "^7.3.0",
     "browserify": "^14.5.0",


### PR DESCRIPTION
The lib/ build probably doesn't need comments and whitespace, so we can use a babel plugin to minify.