### PR TITLE
Test value is null OR undefined for building initialValue

### DIFF
--- a/src/react-super-select.js
+++ b/src/react-super-select.js
@@ -20,6 +20,7 @@ import { bindAll,
          isEmpty,
          isEqual,
          isFunction,
+         isNull,
          isNumber,
          isObject,
          isString,
@@ -389,7 +390,7 @@ class ReactSuperSelect extends React.Component {
     props = props || this.props;
     let initialValue = [];
 
-    if (!isUndefined(props.initialValue)) {
+    if (!isNull(props.initialValue) && !isUndefined(props.initialValue)) {
       initialValue = isArray(props.initialValue) ? props.initialValue : [props.initialValue];
 
       if (!this._isMultiSelect()) {


### PR DESCRIPTION
'undefined' is a painful thing to pass as it is usually is a test for a value not being provided at all.
Makes checks in React lifecycle methods like componentWillReceiveProps for updated props difficult.

Testing for 'null' shouldn't break anything